### PR TITLE
Fixing composer.json bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,8 @@
         "php": ">=5.0.0"
     },
     "autoload": {
-        "classmap": [
-            "src",
-            "Template.php"
+        "files": [
+            "src/Template.php"
         ]
     }
 }


### PR DESCRIPTION
When installing php-template with Composer, a warning was given. This pull request fixes that warning by explicitly specifying the file to load.
